### PR TITLE
Add rounded material icons

### DIFF
--- a/packages/react-icons-ng/src/icons/index.ts
+++ b/packages/react-icons-ng/src/icons/index.ts
@@ -743,6 +743,18 @@ export const icons: IconDefinition[] = [
           )}`,
         processWithSVGO: true,
       },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/material-design-icons/src/*/*/materialiconsround/24px.svg",
+        ),
+        formatter: (name, file) =>
+          `MdRound${camelcase(
+            file.replace(/^.*\/([^/]+)\/materialicons[^/]*\/24px.svg$/i, "$1"),
+            { pascalCase: true },
+          )}`,
+        processWithSVGO: true,
+      },
     ],
     projectUrl: "https://google.github.io/material-design-icons/",
     license: "Apache License Version 2.0",


### PR DESCRIPTION
Can we add Rounded Material Icons to be included in the build?

Awesome library. Thank you!

Screenshot with `preview`:

![image](https://github.com/user-attachments/assets/b33ac55d-032d-4761-b31e-95ed8dfbdf8c)